### PR TITLE
Implement TimeEntry persistence

### DIFF
--- a/payroll-automation/src/main/java/com/czen/payroll_automation/controller/PayrollController.java
+++ b/payroll-automation/src/main/java/com/czen/payroll_automation/controller/PayrollController.java
@@ -1,7 +1,7 @@
 package com.czen.payroll_automation.controller;
 
 import com.czen.payroll_automation.model.TimeEntry;
-import com.czen.payroll_automation.service.ValidationService;
+import com.czen.payroll_automation.service.TimeEntryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,20 +13,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/payroll")
 public class PayrollController {
 
-    private final ValidationService validationService;
+    private final TimeEntryService timeEntryService;
 
     @Autowired
-    public PayrollController(ValidationService validationService) {
-        this.validationService = validationService;
+    public PayrollController(TimeEntryService timeEntryService) {
+        this.timeEntryService = timeEntryService;
     }
 
-    @PostMapping("/validate")
-    public ResponseEntity<String> validateTimeEntry(@RequestBody TimeEntry timeEntry) {
-        boolean isValid = validationService.validateTimeEntry(timeEntry);
-        if (isValid) {
-            return ResponseEntity.ok("Time entry is valid.");
-        } else {
-            return ResponseEntity.badRequest().body("Time entry is invalid.");
+    @PostMapping("/time-entries")
+    public ResponseEntity<String> submitTimeEntry(@RequestBody TimeEntry timeEntry) {
+        try {
+            timeEntryService.saveTimeEntry(timeEntry);
+            return ResponseEntity.ok("Time entry saved successfully.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 }

--- a/payroll-automation/src/main/java/com/czen/payroll_automation/repository/TimeEntryRepository.java
+++ b/payroll-automation/src/main/java/com/czen/payroll_automation/repository/TimeEntryRepository.java
@@ -1,0 +1,9 @@
+package com.czen.payroll_automation.repository;
+
+import com.czen.payroll_automation.model.TimeEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TimeEntryRepository extends JpaRepository<TimeEntry, Long> {
+}

--- a/payroll-automation/src/main/java/com/czen/payroll_automation/service/TimeEntryService.java
+++ b/payroll-automation/src/main/java/com/czen/payroll_automation/service/TimeEntryService.java
@@ -1,0 +1,26 @@
+package com.czen.payroll_automation.service;
+
+import com.czen.payroll_automation.model.TimeEntry;
+import com.czen.payroll_automation.repository.TimeEntryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TimeEntryService {
+
+    private final ValidationService validationService;
+    private final TimeEntryRepository timeEntryRepository;
+
+    @Autowired
+    public TimeEntryService(ValidationService validationService, TimeEntryRepository timeEntryRepository) {
+        this.validationService = validationService;
+        this.timeEntryRepository = timeEntryRepository;
+    }
+
+    public TimeEntry saveTimeEntry(TimeEntry timeEntry) {
+        if (!validationService.validateTimeEntry(timeEntry)) {
+            throw new IllegalArgumentException("Time entry is invalid.");
+        }
+        return timeEntryRepository.save(timeEntry);
+    }
+}

--- a/payroll-automation/src/test/java/com/czen/payroll_automation/FullIntegrationTest.java
+++ b/payroll-automation/src/test/java/com/czen/payroll_automation/FullIntegrationTest.java
@@ -4,6 +4,7 @@ import com.czen.payroll_automation.model.Department;
 import com.czen.payroll_automation.model.Employee;
 import com.czen.payroll_automation.model.JobCode;
 import com.czen.payroll_automation.model.TimeEntry;
+import com.czen.payroll_automation.repository.TimeEntryRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,6 +25,9 @@ public class FullIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private TimeEntryRepository timeEntryRepository;
 
     @Test
     public void testValidTimeEntry() {
@@ -48,14 +52,17 @@ public class FullIntegrationTest {
 
         // When
         ResponseEntity<String> response = restTemplate.postForEntity(
-                "http://localhost:" + port + "/api/payroll/validate",
+                "http://localhost:" + port + "/api/payroll/time-entries",
                 request,
                 String.class
         );
 
         // Then
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).isEqualTo("Time entry is valid.");
+        assertThat(response.getBody()).isEqualTo("Time entry saved successfully.");
+
+        // Verify persistence
+        assertThat(timeEntryRepository.count()).isGreaterThan(0);
     }
 
     @Test
@@ -81,7 +88,7 @@ public class FullIntegrationTest {
 
         // When
         ResponseEntity<String> response = restTemplate.postForEntity(
-                "http://localhost:" + port + "/api/payroll/validate",
+                "http://localhost:" + port + "/api/payroll/time-entries",
                 request,
                 String.class
         );

--- a/payroll-automation/src/test/java/com/czen/payroll_automation/controller/PayrollControllerTest.java
+++ b/payroll-automation/src/test/java/com/czen/payroll_automation/controller/PayrollControllerTest.java
@@ -27,7 +27,7 @@ class PayrollControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
-    void testValidateTimeEntry_Valid() throws Exception {
+    void testSubmitTimeEntry_Valid() throws Exception {
         Employee employee = new Employee();
         employee.setId(1L);
         Department department = new Department();
@@ -39,15 +39,15 @@ class PayrollControllerTest {
         timeEntry.setDepartment(department);
         timeEntry.setJobCode(jobCode);
 
-        mockMvc.perform(post("/api/payroll/validate")
+        mockMvc.perform(post("/api/payroll/time-entries")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(timeEntry)))
                 .andExpect(status().isOk())
-                .andExpect(content().string("Time entry is valid."));
+                .andExpect(content().string("Time entry saved successfully."));
     }
 
     @Test
-    void testValidateTimeEntry_Invalid() throws Exception {
+    void testSubmitTimeEntry_Invalid() throws Exception {
         Employee employee = new Employee();
         employee.setId(99L); // Non-existent employee
         Department department = new Department();
@@ -59,7 +59,7 @@ class PayrollControllerTest {
         timeEntry.setDepartment(department);
         timeEntry.setJobCode(jobCode);
 
-        mockMvc.perform(post("/api/payroll/validate")
+        mockMvc.perform(post("/api/payroll/time-entries")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(timeEntry)))
                 .andExpect(status().isBadRequest())

--- a/payroll-automation/src/test/java/com/czen/payroll_automation/service/TimeEntryServiceTest.java
+++ b/payroll-automation/src/test/java/com/czen/payroll_automation/service/TimeEntryServiceTest.java
@@ -1,0 +1,62 @@
+package com.czen.payroll_automation.service;
+
+import com.czen.payroll_automation.model.TimeEntry;
+import com.czen.payroll_automation.repository.TimeEntryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.any;
+
+class TimeEntryServiceTest {
+
+    @Mock
+    private ValidationService validationService;
+
+    @Mock
+    private TimeEntryRepository timeEntryRepository;
+
+    @InjectMocks
+    private TimeEntryService timeEntryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testSaveTimeEntry_Valid() {
+        TimeEntry timeEntry = new TimeEntry();
+
+        when(validationService.validateTimeEntry(timeEntry)).thenReturn(true);
+        when(timeEntryRepository.save(timeEntry)).thenReturn(timeEntry);
+
+        TimeEntry savedEntry = timeEntryService.saveTimeEntry(timeEntry);
+
+        assertEquals(timeEntry, savedEntry);
+        verify(validationService).validateTimeEntry(timeEntry);
+        verify(timeEntryRepository).save(timeEntry);
+    }
+
+    @Test
+    void testSaveTimeEntry_Invalid() {
+        TimeEntry timeEntry = new TimeEntry();
+
+        when(validationService.validateTimeEntry(timeEntry)).thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            timeEntryService.saveTimeEntry(timeEntry);
+        });
+
+        assertEquals("Time entry is invalid.", exception.getMessage());
+        verify(validationService).validateTimeEntry(timeEntry);
+        verify(timeEntryRepository, never()).save(any(TimeEntry.class));
+    }
+}


### PR DESCRIPTION
Implemented persistence for TimeEntry by adding a repository and service layer. Updated the controller to expose a submission endpoint that validates and saves the entry. Updated tests to reflect these changes.

---
*PR created automatically by Jules for task [10898840311956070670](https://jules.google.com/task/10898840311956070670) started by @mlukenich*